### PR TITLE
Fix issue setting 'Start time' when already set

### DIFF
--- a/Application/Controller/HomeController.php
+++ b/Application/Controller/HomeController.php
@@ -53,7 +53,7 @@
                     }
 
                     // We obtain total time worked at day                    
-                    $total_time_worked_at_day = $query->getTotalTimeWorkedAtDay(date('Y-m-d'), $_SESSION['id_user']);
+                    $total_time_worked_at_day = $query->getTotalTimeWorkedToday(date('Y-m-d'), $_SESSION['id_user']) ?? '--:--:--';
                     $hours = array_merge(
                         $hours, 
                         ['total_time' => $total_time_worked_at_day]

--- a/Application/Controller/admin/AdminController.php
+++ b/Application/Controller/admin/AdminController.php
@@ -77,7 +77,7 @@ final class AdminController extends Controller
 
                 $hours_by_user = [
                     'hours'      => $queryHourlyControl->getTotalTimeWorkedAtDayByUser($fields['date'], $fields['user']),
-                    'total_time' => $queryHourlyControl->getTotalTimeWorkedAtDay($fields['date'], $fields['user']),
+                    'total_time' => $queryHourlyControl->getTotalTimeWorkedToday($fields['date'], $fields['user']),
                 ];
 
                 // Add hours to variables

--- a/Application/Controller/hourlycontrol/HourlyController.php
+++ b/Application/Controller/hourlycontrol/HourlyController.php
@@ -5,7 +5,8 @@ declare(strict_types = 1);
 namespace Application\Controller\hourlycontrol;
 
 use App\Core\Controller;
-use model\classes\Query;
+use DateTime;
+use model\classes\QueryHourlyControl;
 
 class HourlyController extends Controller
 {
@@ -16,8 +17,43 @@ class HourlyController extends Controller
             // Test for privileges
             if(!$this->testAccess(['ROLE_USER', 'ROLE_ADMIN'])) throw new \Exception('Only authorized users can access this page');
 
+            // Test if there is already an input done without an output
+            $queryHourlyControl = new QueryHourlyControl();
+                       
             $dateIn = date('Y-m-d H:i:s');
-            $query = new Query();
+            $query = new QueryHourlyControl();
+
+            if(!$queryHourlyControl->isValidRow($_SESSION['id_user'])) {
+                $rows  = $query->testWorkState();
+
+                $workstate       = ($rows && $rows['date_out'] === null && $rows['date_in'] !== null) ? 'Working' : 'Not Working';
+                $workstate_color = ($rows && $rows['date_out'] === null && $rows['date_in'] !== null) ? 'success' : 'danger';
+                
+                // We obtain the input, output hours and total time worked
+                $hours = [
+                    'date_in'  => $rows['date_in']  ? date_format(new DateTime($rows['date_in']), 'H:i:s')  : '--:--:--',
+                    'date_out' => $rows['date_out'] ? date_format(new DateTime($rows['date_out']), 'H:i:s') : '--:--:--',
+                    'duration' => $rows['date_out'] != null ? date_diff(new DateTime($rows['date_in']), new DateTime($rows['date_out']))->format('%H:%I:%S') : '--:--:--',
+                ];
+
+                // We obtain total time worked at day                    
+                $total_time_worked_at_day = $query->getTotalTimeWorkedToday(date('Y-m-d'), $_SESSION['id_user']);
+                $hours = array_merge(
+                    $hours, 
+                    ['total_time' => $total_time_worked_at_day]
+                );                
+                
+                $this->render('main_view.twig', [
+                        'menus' => $this->showNavLinks(),
+                        'session' => $_SESSION,
+                        'workstate'       => $workstate,
+                        'workstate_color' => $workstate_color,
+                        'hours'           => $hours,
+                        'active' => 'home',
+                        'error_message' => "Start time is already set",
+                ]);                
+            }
+
             $query->insertInto("hourly_control", [
                 "id_user" => $_SESSION['id_user'],
                 "date_in" => $dateIn

--- a/Application/model/classes/Query.php
+++ b/Application/model/classes/Query.php
@@ -328,5 +328,24 @@
                 throw new \Exception("{$th->getMessage()}");
             }
         }
+
+        public function selectFieldsFromTableById(array $fields, string $table, string $fieldId, string $value): array
+        {
+            $fields = implode(", ", $fields);
+            $query = "SELECT $fields FROM $table WHERE $fieldId = :value";
+
+            try {
+                $stm = $this->dbcon->pdo->prepare($query);
+                $stm->bindValue(":value", $value);                                                   
+                $stm->execute();       
+                $rows = $stm->fetch(PDO::FETCH_ASSOC);
+                $stm->closeCursor();
+            
+                return $rows;
+
+            } catch (\Throwable $th) {
+                throw new \Exception("{$th->getMessage()}");
+            }
+        }
     }    
 ?>

--- a/Application/view/main_view.twig
+++ b/Application/view/main_view.twig
@@ -13,7 +13,7 @@
                         <th>Start time</th>
                         <th>Exit time</th>
                         <th>Duration</th>
-                        <th>Total worked at day</th>
+                        <th>Total worked today</th>
                     </tr>
                 </thead>
                 <tbody>                   


### PR DESCRIPTION
Fix the issue on setting the "Start time" when already is set. When you press a second time the "Enter" button, the start time is reset to the current time. Now this problem is fixed and shows an alert message like this "Start time is already set".